### PR TITLE
Make markdown a detectable language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable


### PR DESCRIPTION
Currently Github shows this repo as "no language" this PR changes it to this
![image](https://github.com/lit/rfcs/assets/16060205/82b1690f-58a4-46d9-abe9-9b411ed7b429)

Documentation for this behavior is here: https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#summary